### PR TITLE
Create lightning component bundles and additional option flag usecurrentfolder

### DIFF
--- a/commands/code_create.js
+++ b/commands/code_create.js
@@ -37,6 +37,12 @@ const codeCreate = require('../lib/code_create.js');
       description: 'variables required by the template',
       hasValue: true,
       required: false
+    }, {
+      name: 'usecurrentfolder',
+      char: 'c',
+      description: 'use current working directory to look for .sfdx-templates',
+      hasValue: false,
+      required: false
     }],
     run(context) {
 
@@ -44,8 +50,9 @@ const codeCreate = require('../lib/code_create.js');
       const name = context.flags.name;
       const outputdir = context.flags.outputdir;
       const vars = context.flags.vars;
+      const usecurrentfolder = context.flags.usecurrentfolder;
 
-      let templateFolder = path.join(os.homedir(), '.sfdx-templates', template);
+      let templateFolder = usecurrentfolder ? path.join('./', '.sfdx-templates', template) :  path.join(os.homedir(), '.sfdx-templates', template);
       if (!fse.existsSync(templateFolder)) {
         templateFolder = path.join(__dirname, '../templates', template);
       }

--- a/lib/code_create.js
+++ b/lib/code_create.js
@@ -61,6 +61,10 @@ function createFiles(templateFolder, name, template, vars, outputdir, done) {
       // if bundle flagged as true, add all the files in a folder with the same name
       if (defJsonBundle) {
         newFile = path.join(outputdir, name, `${name}.${fileExtension}`);
+        // lightning components 
+        if(`${fileExtension}` === 'Helper.js' || `${fileExtension}` === "Controller.js"){
+          newFile = path.join(outputdir, name, `${name}${fileExtension}`);
+        }
       } 
 
       const newFilePath = path.dirname(newFile);


### PR DESCRIPTION
If `dev.json` defines the template as bundle and fileExtensions are set to `Controller.js` or `Helper.js` lightning component bundles are created correctly. 

Use `--usecurrentfolder` (`-c`) flag to have `code:create` look for template folder `.sfdx-templates` in current working directory. This flag facilitates sharing of templates in a repo. 